### PR TITLE
Add notification method for bigquery allowed emails

### DIFF
--- a/Doppler.BigQueryMicroservice.Test/BigQueryTest.cs
+++ b/Doppler.BigQueryMicroservice.Test/BigQueryTest.cs
@@ -1,5 +1,6 @@
 using Dapper;
 using Doppler.BigQueryMicroservice.Entitites;
+using Doppler.BigQueryMicroservice.Entitites.EmailSender;
 using Doppler.BigQueryMicroservice.Repository;
 using Doppler.BigQueryMicroservice.Serialization;
 using Doppler.BigQueryMicroservice.Services;
@@ -8,6 +9,7 @@ using Flurl.Http.Testing;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Dapper;
 using Newtonsoft.Json;
@@ -179,7 +181,7 @@ namespace Doppler.BigQueryMicroservice
         public async Task PUT_save_allowed_emails_user_found()
         {
             #region Arrange
-            var dbResponse = new[] { new User { Email = "cgil@makingsense.com", IdUser = 103021, Languaje = "en" } };
+            var dbResponse = new[] { new User { Email = "cgil@makingsense.com", IdUser = 103021, Language = "en" } };
             var parameter = new AllowedEmails();
             parameter.Emails.Add("cristiancamilo110133@gmail.com");
             var json = JsonConvert.SerializeObject(parameter);
@@ -226,7 +228,7 @@ namespace Doppler.BigQueryMicroservice
             var userId = 1;
             var userEmail = "dummy@email.com";
             var emails = new List<string> { "nuevo@gmail.com", "nuevo2@gmail.com" };
-            var user = new User { Email = userEmail, IdUser = userId, Languaje = "en" };
+            var user = new User { Email = userEmail, IdUser = userId, Language = "en" };
             var mergeResult = new MergeEmailResult(emails);
             var requestBody = new { Emails = emails };
 
@@ -269,7 +271,7 @@ namespace Doppler.BigQueryMicroservice
             var userId = 1;
             var userEmail = "dummy@email.com";
             var emails = new List<string> { "dummy@email.com" };
-            var user = new User { Email = userEmail, IdUser = userId, Languaje = "en" };
+            var user = new User { Email = userEmail, IdUser = userId, Language = "en" };
             var mergeResult = new MergeEmailResult(emails);
             var requestBody = new { Emails = emails };
 
@@ -303,6 +305,90 @@ namespace Doppler.BigQueryMicroservice
             //Assert
             httpTest.ShouldNotHaveMadeACall();
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task SaveAllowedEmails_should_return_200_when_user_language_is_null()
+        {
+            //Arrange
+            using var httpTest = new HttpTest();
+            httpTest.RespondWith("", 200);
+            var userEmail = "dummy@email.com";
+            var userId = 1;
+            var emails = new List<string> { "dummy@email.com" };
+            var user = new User { Email = userEmail, IdUser = userId };
+            var mergeResult = new MergeEmailResult(emails);
+            var requestBody = new { Emails = emails };
+
+            var userRepositoryMock = new Mock<IUserRepository>();
+            userRepositoryMock.Setup(x => x.GetUserByEmail(userEmail)).ReturnsAsync(user);
+
+            var userAccessByUserRepositoryMock = new Mock<IUserAccessByUserRepository>();
+            userAccessByUserRepositoryMock.Setup(x => x.MergeEmailsAsync(userId, emails)).ReturnsAsync(mergeResult);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(userRepositoryMock.Object);
+                    services.AddSingleton(userAccessByUserRepositoryMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Put, $"big-query/{userEmail}/allowed-emails")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } },
+                Content = JsonContent.Create(requestBody)
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            //Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public void SaveAllowedEmails_should_validate_change_of_template_and_default()
+        {
+            //Arrange
+            var userEmail = "dummy@email.com";
+            var userId = 1;
+            var englishTemplate = "xxxxxxyyyyyzzzz";
+            var spanishTemplate = "zzzzzzyyyyyxxxx";
+
+            var expectedTemplateEn = new Dictionary<string, string>();
+            expectedTemplateEn.Add("en", "xxxxxxyyyyyzzzz");
+            var optionsTemplateEn = new EmailNotificationsConfiguration() { BigQueryInvitationTemplateId = expectedTemplateEn };
+
+            var expectedTemplateEs = new Dictionary<string, string>();
+            expectedTemplateEs.Add("es", "zzzzzzyyyyyxxxx");
+            var optionsTemplateEs = new EmailNotificationsConfiguration() { BigQueryInvitationTemplateId = expectedTemplateEs };
+
+            var userEn = new User { Email = userEmail, IdUser = userId, Language = "en" };
+            var userEs = new User { Email = userEmail, IdUser = userId, Language = "es" };
+            var userEmpty = new User { Email = userEmail, IdUser = userId };
+
+            var emailEnSettingsMock = new Mock<IOptions<EmailNotificationsConfiguration>>();
+            emailEnSettingsMock.Setup(x => x.Value).Returns(optionsTemplateEn);
+
+            var emailEsSettingsMock = new Mock<IOptions<EmailNotificationsConfiguration>>();
+            emailEsSettingsMock.Setup(x => x.Value).Returns(optionsTemplateEs);
+
+            var emailDefaultSettingsMock = new Mock<IOptions<EmailNotificationsConfiguration>>();
+            emailDefaultSettingsMock.Setup(x => x.Value).Returns(optionsTemplateEn);
+
+            // Act
+            var templateEn = emailEnSettingsMock.Object.Value.BigQueryInvitationTemplateId[userEn.Language];
+            var templateEs = emailEsSettingsMock.Object.Value.BigQueryInvitationTemplateId[userEs.Language];
+            var templateDefault = emailDefaultSettingsMock.Object.Value.BigQueryInvitationTemplateId[userEmpty.Language ?? "en"];
+
+            //Assert
+            Assert.Equal(englishTemplate, templateEn);
+            Assert.Equal(spanishTemplate, templateEs);
+            Assert.Equal(englishTemplate, templateDefault);
         }
     }
 }

--- a/Doppler.BigQueryMicroservice.Test/BigQueryTest.cs
+++ b/Doppler.BigQueryMicroservice.Test/BigQueryTest.cs
@@ -1,17 +1,23 @@
 using Dapper;
 using Doppler.BigQueryMicroservice.Entitites;
+using Doppler.BigQueryMicroservice.Repository;
 using Doppler.BigQueryMicroservice.Serialization;
+using Doppler.BigQueryMicroservice.Services;
 using Doppler.BigQueryMicroservice.Utils;
-using Microsoft.AspNetCore.Mvc;
+using Flurl.Http.Testing;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Moq.Dapper;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Net.Http.Json;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
@@ -173,7 +179,7 @@ namespace Doppler.BigQueryMicroservice
         public async Task PUT_save_allowed_emails_user_found()
         {
             #region Arrange
-            var dbResponse = new[] { new User { Email = "cgil@makingsense.com", IdUser = 103021 } };
+            var dbResponse = new[] { new User { Email = "cgil@makingsense.com", IdUser = 103021, Languaje = "en" } };
             var parameter = new AllowedEmails();
             parameter.Emails.Add("cristiancamilo110133@gmail.com");
             var json = JsonConvert.SerializeObject(parameter);
@@ -209,8 +215,94 @@ namespace Doppler.BigQueryMicroservice
             #region Assert
             Assert.Equal(expectedContent, responseContent);
             #endregion
-
         }
 
+        [Fact]
+        public async Task SaveAllowedEmails_should_return_200_when_email_notification_fails()
+        {
+            // Arrange
+            using var httpTest = new HttpTest();
+            httpTest.RespondWith("", 500);
+            var userId = 1;
+            var userEmail = "dummy@email.com";
+            var emails = new List<string> { "nuevo@gmail.com", "nuevo2@gmail.com" };
+            var user = new User { Email = userEmail, IdUser = userId, Languaje = "en" };
+            var mergeResult = new MergeEmailResult(emails);
+            var requestBody = new { Emails = emails };
+
+            var userRepositoryMock = new Mock<IUserRepository>();
+            userRepositoryMock.Setup(x => x.GetUserByEmail(userEmail)).ReturnsAsync(user);
+
+            var userAccessByUserRepositoryMock = new Mock<IUserAccessByUserRepository>();
+            userAccessByUserRepositoryMock.Setup(x => x.MergeEmailsAsync(userId, emails)).ReturnsAsync(mergeResult);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(userRepositoryMock.Object);
+                    services.AddSingleton(userAccessByUserRepositoryMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Put, $"big-query/{userEmail}/allowed-emails")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } },
+                Content = JsonContent.Create(requestBody)
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            var responseContent = await response.Content.ReadAsStringAsync();
+            _output.WriteLine(responseContent);
+
+            //Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task SaveAllowedEmails_should_not_call_email_when_not_has_new_permissions()
+        {
+            // Arrange
+            using var httpTest = new HttpTest();
+            var userId = 1;
+            var userEmail = "dummy@email.com";
+            var emails = new List<string> { "dummy@email.com" };
+            var user = new User { Email = userEmail, IdUser = userId, Languaje = "en" };
+            var mergeResult = new MergeEmailResult(emails);
+            var requestBody = new { Emails = emails };
+
+            var userRepositoryMock = new Mock<IUserRepository>();
+            userRepositoryMock.Setup(x => x.GetUserByEmail(userEmail)).ReturnsAsync(user);
+
+            var userAccessByUserRepositoryMock = new Mock<IUserAccessByUserRepository>();
+            userAccessByUserRepositoryMock.Setup(x => x.MergeEmailsAsync(userId, emails)).ReturnsAsync(mergeResult);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(userRepositoryMock.Object);
+                    services.AddSingleton(userAccessByUserRepositoryMock.Object);
+                });
+
+            }).CreateClient(new WebApplicationFactoryClientOptions());
+
+            var request = new HttpRequestMessage(HttpMethod.Put, $"big-query/{userEmail}/allowed-emails")
+            {
+                Headers = { { "Authorization", $"Bearer {TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518}" } },
+                Content = JsonContent.Create(requestBody)
+            };
+
+            // Act
+            var response = await client.SendAsync(request);
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var log = httpTest.CallLog;
+
+            //Assert
+            httpTest.ShouldNotHaveMadeACall();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
     }
 }

--- a/Doppler.BigQueryMicroservice.Test/Doppler.BigQueryMicroservice.Test.csproj
+++ b/Doppler.BigQueryMicroservice.Test/Doppler.BigQueryMicroservice.Test.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.36.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.8" />
     <PackageReference Include="Moq.Dapper" Version="1.0.4" />

--- a/Doppler.BigQueryMicroservice.Test/Doppler.BigQueryMicroservice.Test.csproj
+++ b/Doppler.BigQueryMicroservice.Test/Doppler.BigQueryMicroservice.Test.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.8" />
     <PackageReference Include="Moq.Dapper" Version="1.0.4" />

--- a/Doppler.BigQueryMicroservice.Test/Doppler.BigQueryMicroservice.Test.csproj
+++ b/Doppler.BigQueryMicroservice.Test/Doppler.BigQueryMicroservice.Test.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.36.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.8" />
     <PackageReference Include="Moq.Dapper" Version="1.0.4" />

--- a/Doppler.BigQueryMicroservice.Test/EmailServiceTest.cs
+++ b/Doppler.BigQueryMicroservice.Test/EmailServiceTest.cs
@@ -18,7 +18,7 @@ namespace Doppler.BigQueryMicroservice
     /// <summary>
     /// Unit test for email service
     /// </summary>
-    public class EmailServiceTest : IClassFixture<WebApplicationFactory<Startup>>
+    public class EmailServiceTest
     {
         private const string SendTemplateUrl = "https://api.dopplerrelay.com/accounts/{accountId}/templates/{templateId}/message";
 
@@ -47,7 +47,7 @@ namespace Doppler.BigQueryMicroservice
             };
 
             IFlurlClientFactory factory = new PerBaseUrlFlurlClientFactory();
-            var sut = new RelayEmailSender(Options.Create(configuration), Mock.Of<ILogger<RelayEmailSender>>() , factory);
+            var sut = new RelayEmailSender(Options.Create(configuration), Mock.Of<ILogger<RelayEmailSender>>(), factory);
 
             using (var httpTest = new HttpTest())
             {

--- a/Doppler.BigQueryMicroservice.Test/EmailServiceTest.cs
+++ b/Doppler.BigQueryMicroservice.Test/EmailServiceTest.cs
@@ -1,0 +1,81 @@
+using AutoFixture;
+using Doppler.BigQueryMicroservice.Entitites.EmailSender;
+using Doppler.BigQueryMicroservice.Services;
+using Doppler.BigQueryMicroservice.Services.Implementation;
+using Flurl.Http;
+using Flurl.Http.Configuration;
+using Flurl.Http.Testing;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Doppler.BigQueryMicroservice
+{
+    /// <summary>
+    /// Unit test for email service
+    /// </summary>
+    public class EmailServiceTest : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        private const string SendTemplateUrl = "https://api.dopplerrelay.com/accounts/{accountId}/templates/{templateId}/message";
+
+        [Fact]
+        public async Task SendWithTemplateAsync()
+        {
+            // Arrange
+            var fixture = new Fixture();
+            var apiKey = fixture.Create<string>();
+            var relayAccountId = fixture.Create<int>();
+            var relayAccountName = fixture.Create<string>();
+            var relayUserEmail = "salesrelay@dopplerrelay.com";
+            var templateId = fixture.Create<string>();
+            var demoData = fixture.Create<string>();
+            var toEmail = "email@gmail.com";
+            var bccEmail = "copy@copy.com";
+            var expectedUrl = $"https://api.dopplerrelay.com/accounts/{relayAccountId}/templates/{templateId}/message";
+
+            var configuration = new RelayEmailSenderConfiguration()
+            {
+                SendTemplateUrlTemplate = SendTemplateUrl,
+                ApiKey = apiKey,
+                AccountId = relayAccountId,
+                AccountName = relayAccountName,
+                Username = relayUserEmail
+            };
+
+            IFlurlClientFactory factory = new PerBaseUrlFlurlClientFactory();
+            var sut = new RelayEmailSender(Options.Create(configuration), Mock.Of<ILogger<RelayEmailSender>>() , factory);
+
+            using (var httpTest = new HttpTest())
+            {
+                // Act
+                await sut.SendWithTemplateAsync(
+                    templateId,
+                    new { demoData = demoData },
+                    new[] { toEmail },
+                    bcc: new[] { bccEmail });
+
+                // Assert
+                httpTest
+                    .ShouldHaveCalled(expectedUrl)
+                    .WithVerb(HttpMethod.Post)
+                    .WithOAuthBearerToken(apiKey)
+                    .WithRequestJson(new
+                    {
+                        from_name = (string)null,
+                        from_email = (string)null,
+                        recipients = new[]
+                        {
+                            new { email = toEmail, type = "to" },
+                            new { email = bccEmail, type = "bcc" },
+                        },
+                        attachments = (object)null,
+                        model = new { demoData = demoData }
+                    });
+            }
+        }
+    }
+}

--- a/Doppler.BigQueryMicroservice/Controllers/BigQueryController.cs
+++ b/Doppler.BigQueryMicroservice/Controllers/BigQueryController.cs
@@ -1,7 +1,13 @@
+using Doppler.BigQueryMicroservice.Entitites.EmailSender;
 using Doppler.BigQueryMicroservice.Repository;
 using Doppler.BigQueryMicroservice.Serialization;
+using Doppler.BigQueryMicroservice.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Doppler.BigQueryMicroservice.Controllers
@@ -15,12 +21,23 @@ namespace Doppler.BigQueryMicroservice.Controllers
     {
         private readonly IUserAccessByUserRepository _userAccessByUserRepository;
         private readonly IUserRepository _userRepository;
+        private readonly IEmailSender _emailSender;
+        private readonly ILogger<BigQueryController> _logger;
+        private readonly IOptions<EmailNotificationsConfiguration> _emailSettings;
 
-
-        public BigQueryController(IUserAccessByUserRepository userAccessByUserRepository, IUserRepository userRepository)
+        /// <summary>
+        /// Constructor for dependency injection
+        /// </summary>
+        /// <param name="userAccessByUserRepository">repository with schema datastudio access.</param>
+        /// <param name="userRepository">repository for users from doppler database.</param>
+        /// <param name="emailSender">service for send mails.</param>
+        public BigQueryController(IUserAccessByUserRepository userAccessByUserRepository, IUserRepository userRepository, IEmailSender emailSender, ILogger<BigQueryController> logger, IOptions<EmailNotificationsConfiguration> emailSettings)
         {
             this._userAccessByUserRepository = userAccessByUserRepository;
             this._userRepository = userRepository;
+            this._emailSender = emailSender;
+            this._logger = logger;
+            this._emailSettings = emailSettings;
         }
 
         [HttpGet("/big-query/{accountName}/allowed-emails")]
@@ -45,8 +62,16 @@ namespace Doppler.BigQueryMicroservice.Controllers
             {
                 return NotFound();
             }
+
             var result = await _userAccessByUserRepository.MergeEmailsAsync(user.IdUser, model.Emails);
-            return Ok(result);
+            var template = _emailSettings.Value.BigQueryInvitationTemplateId["en"];
+
+            if (result.InsertedEmails.Count > 0)
+            {
+                await _emailSender.SafeSendWithTemplateAsync(template, result.InsertedEmails, model.Emails);
+            }
+
+            return Ok(true);
         }
     }
 }

--- a/Doppler.BigQueryMicroservice/Controllers/BigQueryController.cs
+++ b/Doppler.BigQueryMicroservice/Controllers/BigQueryController.cs
@@ -31,7 +31,13 @@ namespace Doppler.BigQueryMicroservice.Controllers
         /// <param name="userAccessByUserRepository">repository with schema datastudio access.</param>
         /// <param name="userRepository">repository for users from doppler database.</param>
         /// <param name="emailSender">service for send mails.</param>
-        public BigQueryController(IUserAccessByUserRepository userAccessByUserRepository, IUserRepository userRepository, IEmailSender emailSender, ILogger<BigQueryController> logger, IOptions<EmailNotificationsConfiguration> emailSettings)
+        public BigQueryController(
+            IUserAccessByUserRepository userAccessByUserRepository,
+            IUserRepository userRepository,
+            IEmailSender emailSender,
+            ILogger<BigQueryController>
+            logger, IOptions<EmailNotificationsConfiguration> emailSettings
+            )
         {
             this._userAccessByUserRepository = userAccessByUserRepository;
             this._userRepository = userRepository;
@@ -64,7 +70,7 @@ namespace Doppler.BigQueryMicroservice.Controllers
             }
 
             var result = await _userAccessByUserRepository.MergeEmailsAsync(user.IdUser, model.Emails);
-            var template = _emailSettings.Value.BigQueryInvitationTemplateId["en"];
+            var template = _emailSettings.Value.BigQueryInvitationTemplateId[user.Language ?? "en"];
 
             if (result.InsertedEmails.Count > 0)
             {

--- a/Doppler.BigQueryMicroservice/Doppler.BigQueryMicroservice.csproj
+++ b/Doppler.BigQueryMicroservice/Doppler.BigQueryMicroservice.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.90" />
     <PackageReference Include="Dapper.SqlBuilder" Version="2.0.78" />
+    <PackageReference Include="Flurl.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
@@ -22,6 +23,7 @@
     <PackageReference Include="Serilog.Sinks.Loggly" Version="5.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
   </ItemGroup>
 
 </Project>

--- a/Doppler.BigQueryMicroservice/Entitites/EmailSender/Attachment.cs
+++ b/Doppler.BigQueryMicroservice/Entitites/EmailSender/Attachment.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Doppler.BigQueryMicroservice.Entitites.EmailSender
+{
+    /// <summary>
+    /// Attachment Abstraction for email sender
+    /// </summary>
+    public class Attachment
+    {
+        public string ContentType { get; set; }
+        public string Filename { get; set; }
+        public byte[] Content { get; set; }
+    }
+}

--- a/Doppler.BigQueryMicroservice/Entitites/EmailSender/EmailNotificationsConfiguration.cs
+++ b/Doppler.BigQueryMicroservice/Entitites/EmailSender/EmailNotificationsConfiguration.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Doppler.BigQueryMicroservice.Entitites.EmailSender
+{
+    public class EmailNotificationsConfiguration
+    {
+        public Dictionary<string, string> BigQueryInvitationTemplateId { get; set; }
+    }
+}

--- a/Doppler.BigQueryMicroservice/Entitites/EmailSender/RelayEmailSenderConfiguration.cs
+++ b/Doppler.BigQueryMicroservice/Entitites/EmailSender/RelayEmailSenderConfiguration.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Doppler.BigQueryMicroservice.Entitites.EmailSender
+{
+    /// <summary>
+    /// Relay email sender configuration
+    /// </summary>
+    public class RelayEmailSenderConfiguration
+    {
+        public string SendUrlTemplate { get; set; }
+        public string SendTemplateUrlTemplate { get; set; }
+        public string ApiKey { get; set; }
+        public int AccountId { get; set; }
+        public string AccountName { get; set; }
+        public string Username { get; set; }
+        public string FromName { get; set; }
+        public string FromAddress { get; set; }
+    }
+}

--- a/Doppler.BigQueryMicroservice/Entitites/MergeResponse.cs
+++ b/Doppler.BigQueryMicroservice/Entitites/MergeResponse.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Doppler.BigQueryMicroservice.Entitites
+{
+    public class MergeResponse
+    {
+        public string Action { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/Doppler.BigQueryMicroservice/Entitites/User.cs
+++ b/Doppler.BigQueryMicroservice/Entitites/User.cs
@@ -7,6 +7,6 @@ namespace Doppler.BigQueryMicroservice.Entitites
     {
         public int IdUser { get; set; }
         public string Email { get; set; }
-
+        public string Language { get; set; }
     }
 }

--- a/Doppler.BigQueryMicroservice/Infrastructure/ServiceRegistration.cs
+++ b/Doppler.BigQueryMicroservice/Infrastructure/ServiceRegistration.cs
@@ -1,5 +1,8 @@
 using Doppler.BigQueryMicroservice.Repository;
 using Doppler.BigQueryMicroservice.Repository.Implementation;
+using Doppler.BigQueryMicroservice.Services;
+using Doppler.BigQueryMicroservice.Services.Implementation;
+using Flurl.Http.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Doppler.BigQueryMicroservice.Infrastructure
@@ -10,6 +13,8 @@ namespace Doppler.BigQueryMicroservice.Infrastructure
         {
             services.AddTransient<IUserAccessByUserRepository, UserAccessByUserRepository>();
             services.AddTransient<IUserRepository, UserRepository>();
+            services.AddSingleton<IFlurlClientFactory, PerBaseUrlFlurlClientFactory>();
+            services.AddTransient<IEmailSender, RelayEmailSender>();
             services.AddTransient<IDatabaseConnectionFactory, DatabaseConnectionFactory>();
         }
     }

--- a/Doppler.BigQueryMicroservice/Repository/EmailResult.cs
+++ b/Doppler.BigQueryMicroservice/Repository/EmailResult.cs
@@ -1,0 +1,6 @@
+using System.Collections.Generic;
+
+namespace Doppler.BigQueryMicroservice.Entitites
+{
+    public record MergeEmailResult(List<string> InsertedEmails);
+}

--- a/Doppler.BigQueryMicroservice/Repository/IUserAccessByUserRepository.cs
+++ b/Doppler.BigQueryMicroservice/Repository/IUserAccessByUserRepository.cs
@@ -10,6 +10,6 @@ namespace Doppler.BigQueryMicroservice.Repository
     public interface IUserAccessByUserRepository : IBaseRepository<UserAccessByUser>
     {
         Task<IReadOnlyList<UserAccessByUser>> GetAllByUserIdAsync(int id);
-        Task<bool> MergeEmailsAsync(int userId, List<string> emails);
+        Task<MergeEmailResult> MergeEmailsAsync(int userId, List<string> emails);
     }
 }

--- a/Doppler.BigQueryMicroservice/Repository/Implementation/UserRepository.cs
+++ b/Doppler.BigQueryMicroservice/Repository/Implementation/UserRepository.cs
@@ -16,8 +16,10 @@ namespace Doppler.BigQueryMicroservice.Repository.Implementation
         public async Task<User> GetUserByEmail(string accountName)
         {
             var builder = new SqlBuilder();
-            builder.Select("IdUser").Select("Email").Where($"Email = @AccountName");
-            var builderTemplate = builder.AddTemplate($"Select /**select**/ from {TableName} /**where**/");
+            builder.Select("u.IdUser").Select("u.Email").Select("l.Name as Language");
+            builder.InnerJoin("[dbo].[Language] l on l.IdLanguage = u.IdLanguage");
+            builder.Where($"Email = @AccountName");
+            var builderTemplate = builder.AddTemplate($"Select /**select**/ from {TableName} u /**innerjoin**/ /**where**/");
             using (var connection = await CreateConnectionAsync())
             {
                 try

--- a/Doppler.BigQueryMicroservice/Services/IEmailSender.cs
+++ b/Doppler.BigQueryMicroservice/Services/IEmailSender.cs
@@ -1,0 +1,34 @@
+using Doppler.BigQueryMicroservice.Entitites.EmailSender;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Doppler.BigQueryMicroservice.Services
+{
+    public interface IEmailSender
+    {
+        Task SendWithTemplateAsync(
+            string templateId,
+            object templateModel,
+            IEnumerable<string> to,
+            IEnumerable<string> cc = null,
+            IEnumerable<string> bcc = null,
+            string fromName = null,
+            string fromAddress = null,
+            IEnumerable<Attachment> attachments = null,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        Task<bool> SafeSendWithTemplateAsync(
+            string templateId,
+            object templateModel,
+            IEnumerable<string> to,
+            IEnumerable<string> cc = null,
+            IEnumerable<string> bcc = null,
+            string fromName = null,
+            string fromAddress = null,
+            IEnumerable<Attachment> attachments = null,
+            CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/Doppler.BigQueryMicroservice/Services/Implementation/RelayEmailSender.cs
+++ b/Doppler.BigQueryMicroservice/Services/Implementation/RelayEmailSender.cs
@@ -1,0 +1,83 @@
+using Doppler.BigQueryMicroservice.Entitites.EmailSender;
+using Doppler.BigQueryMicroservice.Utils;
+using Flurl.Http;
+using Flurl.Http.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Tavis.UriTemplates;
+
+namespace Doppler.BigQueryMicroservice.Services.Implementation
+{
+    public class RelayEmailSender : IEmailSender
+    {
+        private readonly ILogger<RelayEmailSender> _logger;
+        private readonly RelayEmailSenderConfiguration _config;
+        private readonly IFlurlClient _flurlClient;
+
+        public RelayEmailSender(IOptions<RelayEmailSenderConfiguration> config, ILogger<RelayEmailSender> logger, IFlurlClientFactory flurlClientFac)
+        {
+            _config = config.Value;
+            _logger = logger;
+            _flurlClient = flurlClientFac.Get(_config.SendTemplateUrlTemplate).WithOAuthBearerToken(_config.ApiKey);
+        }
+
+        public async Task<bool> SafeSendWithTemplateAsync(string templateId, object templateModel, IEnumerable<string> to, IEnumerable<string> cc = null, IEnumerable<string> bcc = null, string fromName = null, string fromAddress = null, IEnumerable<Attachment> attachments = null, CancellationToken cancellationToken = default)
+        {
+            {
+                try
+                {
+                    await SendWithTemplateAsync(templateId, templateModel, to, cc, bcc, fromName, fromAddress, attachments, cancellationToken);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error sending email with template");
+                    return false;
+                }
+            }
+        }
+
+        public async Task SendWithTemplateAsync(
+            string templateId, object templateModel,
+            IEnumerable<string> to,
+            IEnumerable<string> cc = null,
+            IEnumerable<string> bcc = null,
+            string fromName = null,
+            string fromAddress = null,
+            IEnumerable<Attachment> attachments = null,
+            CancellationToken cancellationToken = default
+            )
+        {
+            var recipients = (
+                from emailAddress in to.EmptyIfNull()
+                select new { email = emailAddress, type = "to" }).Union(
+                from emailAddress in cc.EmptyIfNull() select new { email = emailAddress, type = "cc" }).Union(
+                from emailAddress in bcc.EmptyIfNull() select new { email = emailAddress, type = "bcc" }).ToArray();
+
+            await _flurlClient.Request(new UriTemplate(_config.SendTemplateUrlTemplate)
+                    .AddParameter("accountId", _config.AccountId)
+                    .AddParameter("accountName", _config.AccountName)
+                    .AddParameter("username", _config.Username)
+                    .AddParameter("templateId", templateId)
+                    .Resolve())
+                .PostJsonAsync(new
+                {
+                    from_name = fromName ?? _config.FromName,
+                    from_email = fromAddress ?? _config.FromAddress,
+                    recipients = recipients,
+                    attachments = attachments?.Select(x => new
+                    {
+                        content_type = x.ContentType.ToString(),
+                        base64_content = Convert.ToBase64String(x.Content),
+                        filename = x.Filename
+                    }),
+                    model = templateModel
+                }, cancellationToken);
+        }
+    }
+}

--- a/Doppler.BigQueryMicroservice/Startup.cs
+++ b/Doppler.BigQueryMicroservice/Startup.cs
@@ -1,16 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using Doppler.BigQueryMicroservice.Entitites.EmailSender;
 using Doppler.BigQueryMicroservice.Infrastructure;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using System;
 
 namespace Doppler.BigQueryMicroservice
 {
@@ -27,6 +23,8 @@ namespace Doppler.BigQueryMicroservice
         public void ConfigureServices(IServiceCollection services)
         {
             services.Configure<DopplerDatabaseSettings>(Configuration.GetSection(nameof(DopplerDatabaseSettings)));
+            services.Configure<RelayEmailSenderConfiguration>(Configuration.GetSection(nameof(RelayEmailSenderConfiguration)));
+            services.Configure<EmailNotificationsConfiguration>(Configuration.GetSection(nameof(EmailNotificationsConfiguration)));
             services.AddDopplerSecurity();
             services.AddControllers();
             services.AddCors();

--- a/Doppler.BigQueryMicroservice/Utils/EnumerableExtensions.cs
+++ b/Doppler.BigQueryMicroservice/Utils/EnumerableExtensions.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Doppler.BigQueryMicroservice.Utils
+{
+    public static class EnumerableExtensions
+    {
+        public static IEnumerable<T> EmptyIfNull<T>(this IEnumerable<T> source)
+        {
+            return source ?? Enumerable.Empty<T>();
+        }
+    }
+}

--- a/Doppler.BigQueryMicroservice/appsettings.Development.json
+++ b/Doppler.BigQueryMicroservice/appsettings.Development.json
@@ -14,5 +14,20 @@
   "DopplerDataBaseSettings": {
     "ConnectionString": "Server=192.168.6.33\\INT;Database=Doppler2011;User Id=DopplerAppUser; MultipleActiveResultSets=True;",
     "Password": "123456"
+  },
+  "RelayEmailSenderConfiguration": {
+    "SendTemplateUrlTemplate": "https://api.dopplerrelay.com/accounts/{accountId}/templates/{templateId}/message",
+    "SendUrlTemplate": "https://api.dopplerrelay.com/accounts/{accountId}/messages",
+    "ApiKey": "xxxyyyzzz",
+    "AccountId": 74,
+    "AccountName": "DevDoppler",
+    "Username": "DevDoppler",
+    "FromName": "dopplertest",
+    "FromAddress": "doppler.notification@makingsense.com"
+  },
+  "EmailNotificationsConfiguration": {
+    "BigQueryInvitationTemplateId": {
+      "en": "9b496fea-c6bc-404c-8a77-41ea61cf583d"
+    }
   }
 }

--- a/Doppler.BigQueryMicroservice/appsettings.Development.json
+++ b/Doppler.BigQueryMicroservice/appsettings.Development.json
@@ -27,6 +27,7 @@
   },
   "EmailNotificationsConfiguration": {
     "BigQueryInvitationTemplateId": {
+      "es": "b8ab79ae-7226-4007-86c4-777cd7d39010",
       "en": "9b496fea-c6bc-404c-8a77-41ea61cf583d"
     }
   }

--- a/Doppler.BigQueryMicroservice/appsettings.json
+++ b/Doppler.BigQueryMicroservice/appsettings.json
@@ -19,5 +19,20 @@
   "DopplerDataBaseSettings": {
     "ConnectionString": "Server=REPLACE_FOR_SQL_SERVER;Database=REPLACE_FOR_DATABASE_NAME;User Id=REPLACE_FOR_DATABASE_USERNAME; MultipleActiveResultSets=True;",
     "Password": "REPLACE_FOR_DATABASE_PASSWORD"
+  },
+  "RelayEmailSenderConfiguration": {
+    "SendTemplateUrlTemplate": "https://api.dopplerrelay.com/accounts/{accountId}/templates/{templateId}/message",
+    "SendUrlTemplate": "https://api.dopplerrelay.com/accounts/{accountId}/messages",
+    "ApiKey": "REPLACE_FOR_EMAIL_SENDER_API_KEY",
+    "AccountId": 0,
+    "AccountName": "REPLACE_FOR_EMAIL_SENDER_ACCOUNTNAME",
+    "Username": "REPLACE_FOR_EMAIL_SENDER_USERNAME",
+    "FromName": "CONFIGURE_FROM_NAME",
+    "FromAddress": "CONFIGURE_FROM_EMAIL"
+  },
+  "EmailNotificationsConfiguration": {
+    "BigQueryInvitationTemplateId": {
+      "en": "yyyyyyyy-xxxx-yyyy-xxxx-yyyyyyyyyyyy"
+    }
   }
 }

--- a/Doppler.BigQueryMicroservice/appsettings.json
+++ b/Doppler.BigQueryMicroservice/appsettings.json
@@ -32,6 +32,7 @@
   },
   "EmailNotificationsConfiguration": {
     "BigQueryInvitationTemplateId": {
+      "es": "xxxxxxxx-yyyy-xxxx-yyyy-xxxxxxxxxxxx",
       "en": "yyyyyyyy-xxxx-yyyy-xxxx-yyyyyyyyyyyy"
     }
   }


### PR DESCRIPTION
in this change is include the following changes:

1. a client for doppler relay with flur client.
2. service for encapsulate logic
3. test for new client
3. add configurations for personalized templates configuration
4. add model for parameter of notification
5. refactor to model for post
